### PR TITLE
Add GitHub workflow for Helm linting

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,29 @@
+name: Helm Chart Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.yaml'
+      - '**/*.yml'
+      - '.github/workflows/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.13.1
+
+      - name: Install yamllint
+        run: sudo apt-get update && sudo apt-get install -y yamllint
+
+      - name: Run yamllint
+        run: yamllint .
+
+      - name: Run helm lint
+        run: helm lint .
+


### PR DESCRIPTION
## Summary
- add CI workflow `helm-lint.yml` that installs `helm` and `yamllint`
- run `yamllint` and `helm lint` to validate chart correctness and best practices

## Testing
- `yamllint .` *(fails: many lint errors)*
- `helm lint .` *(fails: `helm: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_6866b83fdd208320a4d7c7faa6b98fc4