### PR TITLE
Update default image

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "latest"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "latest"
+appVersion: "1.16.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-atlassian-helm
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,7 +16,7 @@ A Helm chart for Kubernetes
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/sooperset/mcp-atlassian"` |  |
-| image.tag | string | `"latest"` |  |
+| image.tag | string | `"1.16.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-atlassian-helm
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -15,8 +15,8 @@ A Helm chart for Kubernetes
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"nginx"` |  |
-| image.tag | string | `""` |  |
+| image.repository | string | `"ghcr.io/sooperset/mcp-atlassian"` |  |
+| image.tag | string | `"latest"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/sooperset/mcp-atlassian
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "1.16.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/values.yaml
+++ b/values.yaml
@@ -5,10 +5,10 @@
 replicaCount: 1
 
 image:
-  repository: nginx
+  repository: ghcr.io/sooperset/mcp-atlassian
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- set the default container image repository to `ghcr.io/sooperset/mcp-atlassian`
- default to tag `latest`
- update chart `appVersion` and documentation

## Testing
- `helm lint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b82da3448320bedd648d0f3e3d0a

## Summary by Sourcery

Update the Helm chart to use the new default container image repository and tag, and align the chart appVersion and documentation with "latest".

Enhancements:
- Set the default image.repository to ghcr.io/sooperset/mcp-atlassian and default image.tag to latest
- Update Chart.yaml appVersion from 1.16.0 to latest

Documentation:
- Refresh README badges to show AppVersion as latest