### PR TITLE
Add env secret template

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-atlassian-helm
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -38,4 +38,7 @@ A Helm chart for Kubernetes
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |
+| env | object | `{}` | Extra environment variables |
+| envSecrets | object | `{}` | Environment variables from secrets |
+| secretEnv | object | `{}` | Create secret with environment data |
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -33,6 +33,29 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
+          env:
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ quote $val }}
+            {{- end }}
+            {{- if .Values.secretEnv.data }}
+            {{- range $key, $val := .Values.secretEnv.data }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-env" (include "mcp-atlassian-helm.fullname" $)) .Values.secretEnv.name }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $secret := .Values.envSecrets }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret.name }}
+                  key: {{ $secret.key }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secretEnv.data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-env" (include "mcp-atlassian-helm.fullname" .)) .Values.secretEnv.name }}
+  labels:
+    {{- include "mcp-atlassian-helm.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.secretEnv.data }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -80,3 +80,27 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Additional environment variables to pass to the container.
+# Example:
+# env:
+#   JIRA_URL: https://your-company.atlassian.net
+env: {}
+
+# Environment variables sourced from existing Kubernetes secrets.
+# Example:
+# envSecrets:
+#   JIRA_API_TOKEN:
+#     name: mcp-atlassian-secret
+#     key: jiraApiToken
+envSecrets: {}
+
+# Create a Kubernetes secret from the following data and expose the keys as environment variables.
+# Example:
+# secretEnv:
+#   name: mcp-atlassian-env
+#   data:
+#     JIRA_API_TOKEN: your_jira_token
+#     CONFLUENCE_API_TOKEN: your_conf_token
+secretEnv: {}
+


### PR DESCRIPTION
## Summary
- create secret template for env vars
- mount new secret in deployment and document values
- bump chart version to 0.1.2

## Testing
- `apt-get update`
- `apt-get install -y helm` *(fails: Unable to locate package)*
- `helm lint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bb6dad7483209d58242d36f89a8a